### PR TITLE
fix(workflow): husky cannot use [[ ]] test stynax on WSL2-Ubuntu

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,1 @@
-.husky/** linguist-generated
 * text=auto eol=lf

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -22,7 +22,7 @@ Hi! We're Really excited that you are interested in contributing to Furigana Mak
 - Commit messages must be matched by the following regex:
 
 ```txt
-/^(feat|fix|website|style|refactor|perf|test|workflow|build|ci|chore|types)(\(.+\))?: .{1,50}/
+/^(feat|fix|website|style|refactor|perf|test|build|ci|chore|types|workflow)(\(.+\))?: .{1,50}/
 ```
 
 ## Development Setup

--- a/.husky/commit-msg
+++ b/.husky/commit-msg
@@ -1,16 +1,15 @@
 #!/usr/bin/env bash
-. "$(dirname -- "$0")/_/husky.sh"
 
 message="$(cat $1)"
-requiredPattern="^(feat|fix|website|style|refactor|perf|test|workflow|build|ci|chore|types)(\(.+\))?: .{1,50}"
-if ! [[ $message =~ $requiredPattern ]]; then
+requiredPattern="^(feat|fix|website|style|refactor|perf|test|build|ci|chore|types|workflow)(\(.+\))?: .{1,50}"
+if ! echo "$message" | grep -E "$requiredPattern" >/dev/null; then
     echo "-"
     echo "-"
     echo "-"
     echo "🚨 Wrong commit message! 😕"
     echo "The commit message must have this format:"
     echo "<verb in imperative mood> <what was done>"
-    echo "Allowed verbs in imperative mood: feat|fix|docs|style|refactor|workflow|perf|test|build|ci|chore|types"
+    echo "Allowed verbs in imperative mood: feat|fix|website|style|refactor|perf|test|build|ci|chore|types|workflow"
     echo "Example: feat(style): add new feature"
     echo "-"
     echo "Your commit message was:"

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,4 +1,3 @@
 #!/usr/bin/env bash
-. "$(dirname -- "$0")/_/husky.sh"
 
 npx lint-staged


### PR DESCRIPTION
https://github.com/typicode/husky/issues/1326
The original script reports an error when running on WSL2-Ubuntu: Not found [[

The reason is unknown. The script used before this PR runs normally in git bash. It is a very strange phenomenon that seems to be specific to WSL2-ubuntu...
Modify the script to remove the `[[ ]]` test syntax.