### PR TITLE
fix: "page is too large" warnings too frequent

### DIFF
--- a/packages/extension/commons/selectElement.ts
+++ b/packages/extension/commons/selectElement.ts
@@ -29,7 +29,7 @@ class Renderer {
   readonly #top = document.createElement("div");
   readonly #bottom = document.createElement("div");
   readonly #getTagPath = (element: HTMLElement) => {
-    const parent = element.parentNode as HTMLElement | null;
+    const parent = element.parentElement;
     const parentTagName = parent?.tagName.toLowerCase() ?? "";
     return `${parentTagName} ${element.tagName.toLowerCase()}`;
   };

--- a/packages/extension/public/_locales/en/messages.json
+++ b/packages/extension/public/_locales/en/messages.json
@@ -21,9 +21,9 @@
     "message": "Custom Rule Active"
   },
   "contentScriptWarning": {
-    "message": "Warning(Furigana Maker): This page is too large($htmlSize$KB), auto mode is disabled.",
+    "message": "Warning(Furigana Maker): This page is too large($textLength$ characters), auto mode is disabled.",
     "placeholders": {
-      "htmlSize": {
+      "textLength": {
         "content": "$1"
       }
     }

--- a/packages/extension/public/_locales/ja/messages.json
+++ b/packages/extension/public/_locales/ja/messages.json
@@ -21,9 +21,9 @@
     "message": "カスタムルールがアクティブ"
   },
   "contentScriptWarning": {
-    "message": "警告（Furigana Maker）：このページは大きすぎます（$htmlSize$KB）、自動モードは無効です。",
+    "message": "警告（Furigana Maker）：このページは大きすぎます（$textLength$文字）、自動モードは無効です。",
     "placeholders": {
-      "htmlSize": {
+      "textLength": {
         "content": "$1"
       }
     }

--- a/packages/extension/public/_locales/ko/messages.json
+++ b/packages/extension/public/_locales/ko/messages.json
@@ -21,9 +21,9 @@
     "message": "사용자 규칙 활성화"
   },
   "contentScriptWarning": {
-    "message": "경고(Furigana Maker): 이 페이지는 너무 큽니다($htmlSize$KB), 자동 모드가 비활성화됩니다.",
+    "message": "경고(Furigana Maker): 이 페이지는 너무 큽니다($textLength$자), 자동 모드가 비활성화됩니다.",
     "placeholders": {
-      "htmlSize": {
+      "textLength": {
         "content": "$1"
       }
     }

--- a/packages/extension/public/_locales/zh_CN/messages.json
+++ b/packages/extension/public/_locales/zh_CN/messages.json
@@ -21,9 +21,9 @@
     "message": "自定义规则活跃中"
   },
   "contentScriptWarning": {
-    "message": "警告(Furigana Maker)：此页面过大($htmlSize$KB)，自动模式已禁用。",
+    "message": "警告(Furigana Maker)：此页面过大($textLength$字符)，自动模式已禁用。",
     "placeholders": {
-      "htmlSize": {
+      "textLength": {
         "content": "$1"
       }
     }

--- a/packages/extension/public/_locales/zh_TW/messages.json
+++ b/packages/extension/public/_locales/zh_TW/messages.json
@@ -21,9 +21,9 @@
     "message": "自定義規則活躍中"
   },
   "contentScriptWarning": {
-    "message": "警告(Furigana Maker)：此頁面過大($htmlSize$KB)，自動模式已禁用。",
+    "message": "警告(Furigana Maker)：此頁面過大($textLength$字符)，自動模式已禁用。",
     "placeholders": {
-      "htmlSize": {
+      "textLength": {
         "content": "$1"
       }
     }


### PR DESCRIPTION
close https://github.com/aiktb/FuriganaMaker/issues/16
The following measurement algorithms are much more accurate than before:
```js
function getTextLength() {
  const walker = document.createTreeWalker(document.body, NodeFilter.SHOW_TEXT);
  let textLength = 0;
  while (walker.nextNode()) {
    if (!["SCRIPT", "STYLE"].includes(walker.currentNode.parentElement.tagName)) {
      textLength += walker.currentNode.textContent.length;
    }
  }
  return textLength;
}
getTextLength()
```

- https://x.com/bunorin/status/1870394630635716767 2879
- https://exploringjs.com/js/book/ch_classes.html#ch_classes 77236
- https://ja.wikipedia.org/wiki/JavaScript 23491
- https://ja.wikipedia.org/wiki/%E9%AD%94%E6%B3%95%E7%A7%91%E9%AB%98%E6%A0%A1%E3%81%AE%E5%8A%A3%E7%AD%89%E7%94%9F 187343
- https://furiganamaker.app/welcome 982

The improvement in accuracy is huge!
