### PR TITLE
Potential fix for code scanning alert no. 4: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,6 @@
 name: Lint & TypeCheck & Test
+permissions:
+  contents: read
 on:
   workflow_dispatch:
   pull_request:

--- a/.github/workflows/link.yml
+++ b/.github/workflows/link.yml
@@ -1,5 +1,6 @@
 name: Check for dead links
-
+permissions:
+  contents: read
 on:
   workflow_dispatch:
   schedule:


### PR DESCRIPTION
Potential fix for [https://github.com/aiktb/furiganamaker/security/code-scanning/4](https://github.com/aiktb/furiganamaker/security/code-scanning/4)

To fix the issue, we will add a `permissions` block at the root of the workflow file. This block will specify the minimal permissions required for the workflow to function correctly. Based on the operations in the workflow, the `contents: read` permission is sufficient, as the workflow does not appear to modify repository contents or perform other actions requiring write access.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
