### PR TITLE
fix: display language names in their native locale in language switcher

### DIFF
--- a/apps/extension/src/entrypoints/options/components/LanguageSwitcher.tsx
+++ b/apps/extension/src/entrypoints/options/components/LanguageSwitcher.tsx
@@ -7,12 +7,17 @@ interface LanguageSwitcherProps {
 }
 
 export default function LanguageSwitcher({ language, onChange }: LanguageSwitcherProps) {
-  const displayNameIntl = new Intl.DisplayNames(language, { type: "language" });
+  const getDisplayName = (language: string) => {
+    const langDisplayNames = new Intl.DisplayNames(language, { type: "language" });
+    return langDisplayNames.of(language);
+  };
+
   const { i18n } = useTranslation();
+
   return (
     <Listbox value={language} onChange={onChange}>
       <ListboxButton className="data-[focus]:-outline-offset-2 relative block h-12 min-w-40 cursor-pointer text-nowrap rounded-lg bg-slate-950/5 py-1.5 pr-8 pl-3 text-left text-slate-900 text-sm/6 focus:outline-none focus-visible:outline-current data-[focus]:outline-2 data-[focus]:outline-black/25 dark:bg-white/5 dark:text-white dark:data-[focus]:outline-white/25">
-        {displayNameIntl.of(language)}
+        {getDisplayName(language)}
         <i className="i-tabler-chevron-down group pointer-events-none absolute top-4 right-2.5 size-4 fill-white/60" />
       </ListboxButton>
       <ListboxOptions
@@ -29,7 +34,7 @@ export default function LanguageSwitcher({ language, onChange }: LanguageSwitche
             >
               <i className="i-tabler-check invisible size-4 text-sky-400 group-data-[selected]:visible" />
               <div className="overflow-hidden overflow-ellipsis text-nowrap text-slate-900 text-sm/6 dark:text-white">
-                {displayNameIntl.of(language)}
+                {getDisplayName(language)}
               </div>
             </ListboxOption>
           ))}


### PR DESCRIPTION
- Fix Intl.DisplayNames to use each language's own locale instead of current locale
- Language options now correctly show as "English", "中文", "日本語" etc.
- Resolves issue where all language names appeared in current selected language

This fixes the confusing UX where users couldn't easily identify languages
when they were all displayed in the currently selected locale.