### PR TITLE
fix: the extension modifies the page title

### DIFF
--- a/apps/extension/__TEST__/e2e/content-title.spec.ts
+++ b/apps/extension/__TEST__/e2e/content-title.spec.ts
@@ -1,0 +1,40 @@
+import { describe, expect, test } from "./fixtures";
+
+describe("Content script should not modify <head><title>", () => {
+  test("ruby is added only in body, not in head title", async ({ page }) => {
+    const url = "https://example.org/test-ja";
+    const html = `<!doctype html>
+      <html lang="ja">
+        <head>
+          <meta charset="utf-8" />
+          <title>日本語タイトル</title>
+        </head>
+        <body>
+          <main>
+            <p>漢字テスト</p>
+          </main>
+        </body>
+      </html>`;
+
+    await page.route(url, async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: "text/html; charset=utf-8",
+        body: html,
+      });
+    });
+
+    await page.goto(url);
+    // Wait for the body to be loaded & ruby auto added
+    await page.waitForSelector("body ruby");
+
+    const headRubyCount = await page.$$eval("head ruby", (els) => els.length);
+    expect(headRubyCount).toBe(0);
+
+    const title = await page.title();
+    expect(title).toBe("日本語タイトル");
+
+    const bodyRubyCount = await page.$$eval("body ruby", (els) => els.length);
+    expect(bodyRubyCount).toBeGreaterThan(0);
+  });
+});

--- a/apps/extension/src/commons/addFurigana.ts
+++ b/apps/extension/src/commons/addFurigana.ts
@@ -33,15 +33,18 @@ export async function addFurigana(...elements: Element[]) {
   }
 }
 
-const exclusionParentTagSet = new Set(["SCRIPT", "STYLE", "NOSCRIPT", "RUBY", "RT"]);
+const exclusionParentTagSet = new Set(["SCRIPT", "STYLE", "NOSCRIPT", "RUBY", "RT", "TITLE"]);
 const collectTexts = (element: Element): Text[] => {
   const walker = document.createTreeWalker(element, NodeFilter.SHOW_TEXT);
   const texts: Text[] = [];
   while (walker.nextNode()) {
-    const node = walker.currentNode;
-    const parent = node.parentElement! as Element;
+    const node = walker.currentNode as Text;
+    const parent = node.parentElement as Element | null;
+    if (!parent) {
+      continue;
+    }
     if (!exclusionParentTagSet.has(parent.tagName)) {
-      texts.push(node as Text);
+      texts.push(node);
     }
   }
   return texts;

--- a/apps/extension/src/commons/addFurigana.ts
+++ b/apps/extension/src/commons/addFurigana.ts
@@ -39,7 +39,7 @@ const collectTexts = (element: Element): Text[] => {
   const texts: Text[] = [];
   while (walker.nextNode()) {
     const node = walker.currentNode as Text;
-    const parent = node.parentElement as Element | null;
+    const parent = node.parentElement;
     if (!parent) {
       continue;
     }


### PR DESCRIPTION
# Bug  
<title> element were being collected and processed, causing ruby tags to be added inside head.title.
This resulted in the page title losing its original kanji display.

![furigana_effect_page_meta](https://github.com/user-attachments/assets/f87118f3-b07c-4369-b3f0-ceb2c431edcc)  

# Change  
Initially, I added a check to ensure the element is under document.body.
However, since <title> tags should only appear inside <head>,
we can improve performance by simply checking if the tag name is "TITLE" and skipping it directly,
eliminating unnecessary DOM traversal.