### PR TITLE
feat: add kanji filter search and pagination

### DIFF
--- a/extension/__tests__/e2e/options.spec.ts
+++ b/extension/__tests__/e2e/options.spec.ts
@@ -1,4 +1,5 @@
 import fs from "node:fs";
+import defaultRules from "@/assets/rules/filter.json" with { type: "json" };
 import { DB } from "@/constants";
 import { describe, expect, test } from "../fixtures";
 import { cleanRubyHtml } from "../utils";
@@ -51,7 +52,7 @@ describe("Kanji filter page", () => {
 
   test("Default kanji filters are loaded", async ({ page }) => {
     const kanjiElements = await page.$$(FILTER_ITEM_SELECTOR);
-    expect(kanjiElements.length).toBeGreaterThanOrEqual(995);
+    expect(kanjiElements.length).toBe(100);
     const firstKanji = await kanjiElements.at(0)!.innerText();
     expect(firstKanji).toContain("#1");
     expect(firstKanji).toContain("一");
@@ -62,9 +63,67 @@ describe("Kanji filter page", () => {
     expect(secondKanji).toContain("ヒトリ");
   });
 
+  test("Pagination and search cover all rules", async ({ page }) => {
+    await page.evaluate(
+      ({ name, onlyTable, kanji }) =>
+        new Promise<void>((resolve, reject) => {
+          const request = indexedDB.open(name);
+          request.onerror = () => reject(request.error);
+          request.onsuccess = () => {
+            const db = request.result;
+            const tx = db.transaction(onlyTable, "readwrite");
+            tx.objectStore(onlyTable).put({ kanji });
+            tx.oncomplete = () => {
+              db.close();
+              resolve();
+            };
+            tx.onerror = () => reject(tx.error);
+          };
+        }),
+      { name: DB.name, onlyTable: DB.onlyTable, kanji: defaultRules.at(-1)!.kanji },
+    );
+    await page.reload();
+    const items = page.locator(FILTER_ITEM_SELECTOR);
+    await expect(items).toHaveCount(100);
+    const next = page.getByRole("button", { name: "Next", exact: true });
+    const previous = page.getByRole("button", { name: "Previous", exact: true });
+    await expect(previous).toBeDisabled();
+    await next.click();
+    await expect(items).toHaveCount(100);
+    await expect(items.first()).toContainText("#101");
+    await previous.click();
+    await expect(items.first()).toContainText("#1");
+    for (let i = 1; i < Math.ceil(defaultRules.length / 100); i++) {
+      await next.click();
+    }
+    await expect(next).toBeDisabled();
+    await expect(items).toHaveCount(defaultRules.length % 100 || 100);
+
+    const search = page.getByRole("searchbox");
+    const lastKanji = defaultRules.at(-1)!.kanji;
+    await search.fill(lastKanji);
+    await expect(previous).toBeDisabled();
+    await expect(items.filter({ hasText: lastKanji }).first()).toBeVisible();
+    await search.fill("ヒトリ");
+    await expect(items.filter({ hasText: "一人" }).first()).toBeVisible();
+    await search.fill("no-such-kanji");
+    await expect(items).toHaveCount(0);
+    await expect(page.getByText("No matching rules.")).toBeVisible();
+    await expect(next).toBeDisabled();
+    await search.fill("");
+    await expect(items).toHaveCount(100);
+    await page.getByRole("checkbox", { name: "Only Match ALL rules" }).check();
+    await expect(items).toHaveCount(1);
+    await expect(items.first()).toContainText("Match ALL");
+    await search.fill(lastKanji);
+    await expect(items).toHaveCount(1);
+    await search.fill("一人");
+    await expect(items).toHaveCount(0);
+  });
+
   test("Delete first kanji filter", async ({ page }) => {
     const kanjiElements = await page.$$(FILTER_ITEM_SELECTOR);
-    const kanjiElementCount = kanjiElements.length;
+    const kanjiElementCount = defaultRules.length;
     const firstKanjiElement = kanjiElements.at(0)!;
     const firstKanjiText = await firstKanjiElement.innerText();
 
@@ -102,7 +161,7 @@ describe("Kanji filter page", () => {
     await page.waitForSelector(PAGE_SELECTOR);
     await page.waitForSelector(FILTER_ITEM_SELECTOR);
     const reloadKanjiElements = await page.$$(FILTER_ITEM_SELECTOR);
-    expect(reloadKanjiElements.length).toBe(kanjiElementCount - 1);
+    expect(reloadKanjiElements.length).toBe(100);
     const firstReloadKanjiText = await reloadKanjiElements.at(0)!.innerText();
     expect(firstReloadKanjiText).not.toContain(firstKanjiText);
   });

--- a/extension/__tests__/e2e/options.spec.ts
+++ b/extension/__tests__/e2e/options.spec.ts
@@ -112,7 +112,7 @@ describe("Kanji filter page", () => {
     await expect(next).toBeDisabled();
     await search.fill("");
     await expect(items).toHaveCount(100);
-    await page.getByRole("checkbox", { name: "Only Match ALL rules" }).check();
+    await page.getByRole("switch", { name: "Only Match ALL rules" }).check();
     await expect(items).toHaveCount(1);
     await expect(items.first()).toContainText("Match ALL");
     await search.fill(lastKanji);

--- a/extension/src/assets/_locales/en/translation.json
+++ b/extension/src/assets/_locales/en/translation.json
@@ -102,7 +102,7 @@
   "clearConfigDialogTitle": "Are you sure you want to clear the rule list?",
   "btnClearConfig": "Clear Config",
   "createKanjiFilterDialogTitle": "How to use kanji filter?",
-  "createKanjiFilterDialogDesc1": "Please use the web search tool in your browser to search for a specific kanji or yomikata, then click the button to start editing. Also, the yomikata must be in katakana format, romaji or hiragana are not accepted.",
+  "createKanjiFilterDialogDesc1": "Use the search field to find a kanji or reading across all pages, then click a rule to edit it. Readings must be in katakana; romaji and hiragana are not accepted.",
   "createKanjiFilterDialogDesc2": "The \"Match ALL\" toggle cannot coexist with the yomokatas field. If you switch to this mode, the original yomokatas field will be cleared and cannot be retrieved.",
   "titleKanjiFilterEditor": "{{verbs}} your kanji filter",
   "validationRequired": "Required.",
@@ -138,5 +138,12 @@
   "tipClearText": "Clear text",
   "tipPleaseEnter": "Please enter first.",
   "placeholderTypeFurigana": "Type to furiganaify.",
-  "msgCopyFailed": "Copy failed."
+  "msgCopyFailed": "Copy failed.",
+  "kanjiFilterSearch": "Search kanji or reading",
+  "kanjiFilterMatchAllOnly": "Only Match ALL rules",
+  "kanjiFilterPagination": "Kanji filter pagination",
+  "kanjiFilterPrevious": "Previous",
+  "kanjiFilterNext": "Next",
+  "kanjiFilterPage": "Page {{page}} of {{pages}} · {{total}} rules",
+  "kanjiFilterNoResults": "No matching rules."
 }

--- a/extension/src/assets/_locales/ja/translation.json
+++ b/extension/src/assets/_locales/ja/translation.json
@@ -95,7 +95,7 @@
   "btnConfirm": "確認する",
   "btnQuickCreate": "クイック作成",
   "clearConfigDialogTitle": "ルールリストをクリアしたいですか？",
-  "createKanjiFilterDialogDesc1": "ブラウザのWeb検索ツールを使用して、特定の漢字または読み方を検索し、ボタンをクリックして編集を開始します。\nまた、読み方は片仮名形式である必要があります。ロマジーまたはヒラガナは受け入れられません。",
+  "createKanjiFilterDialogDesc1": "検索欄で全ページの漢字や読み方を検索し、ルールをクリックして編集してください。読み方はカタカナで入力してください。ローマ字やひらがなは使用できません。",
   "createKanjiFilterDialogDesc2": "「すべて」モードは、読み方フィールドと共存できません。\nこのモードに切り替えると、元の読み方フィールドがクリアされ、取得できません。",
   "createKanjiFilterDialogTitle": "漢字フィルターの使用方法は？",
   "fieldMatchAll": "すべて",
@@ -139,5 +139,12 @@
   "tipClearText": "テキストをクリア",
   "tipPleaseEnter": "最初に入力してください。",
   "placeholderTypeFurigana": "文字を入力してふりがな化",
-  "msgCopyFailed": "コピーに失敗しました。"
+  "msgCopyFailed": "コピーに失敗しました。",
+  "kanjiFilterSearch": "漢字または読み方を検索",
+  "kanjiFilterMatchAllOnly": "「すべて」のルールのみ",
+  "kanjiFilterPagination": "漢字フィルターのページ切り替え",
+  "kanjiFilterPrevious": "前へ",
+  "kanjiFilterNext": "次へ",
+  "kanjiFilterPage": "{{page}} / {{pages}} ページ · {{total}} 件",
+  "kanjiFilterNoResults": "一致するルールはありません。"
 }

--- a/extension/src/assets/_locales/zh-CN/translation.json
+++ b/extension/src/assets/_locales/zh-CN/translation.json
@@ -95,7 +95,7 @@
   "btnConfirm": "确认",
   "btnQuickCreate": "快速创建",
   "clearConfigDialogTitle": "您确定要清除规则列表吗？",
-  "createKanjiFilterDialogDesc1": "请在浏览器中使用Web搜索工具搜索特定的汉字或Yomikata，然后单击按钮开始编辑。\n另外，Yomikata必须采用片假名格式，不接受罗马音和平假名。",
+  "createKanjiFilterDialogDesc1": "使用搜索框跨页查找汉字或读音，然后点击规则进行编辑。读音必须使用片假名，不接受罗马音和平假名。",
   "createKanjiFilterDialogDesc2": "“匹配全部”模式不能与Yomokata字段共存。\n如果切换到此模式，将清除原始的Yomokata字段，无法恢复。",
   "createKanjiFilterDialogTitle": "如何使用汉字过滤器？",
   "fieldMatchAll": "匹配全部",
@@ -139,5 +139,12 @@
   "tipClearText": "清除文本",
   "tipPleaseEnter": "请先输入。",
   "placeholderTypeFurigana": "输入文字生成假名",
-  "msgCopyFailed": "复制失败。"
+  "msgCopyFailed": "复制失败。",
+  "kanjiFilterSearch": "搜索汉字或读音",
+  "kanjiFilterMatchAllOnly": "仅显示“匹配全部”规则",
+  "kanjiFilterPagination": "汉字过滤器分页",
+  "kanjiFilterPrevious": "上一页",
+  "kanjiFilterNext": "下一页",
+  "kanjiFilterPage": "第 {{page}} / {{pages}} 页 · 共 {{total}} 条规则",
+  "kanjiFilterNoResults": "没有匹配的规则。"
 }

--- a/extension/src/assets/_locales/zh-TW/translation.json
+++ b/extension/src/assets/_locales/zh-TW/translation.json
@@ -95,7 +95,7 @@
   "btnConfirm": "確認",
   "btnQuickCreate": "快速創建",
   "clearConfigDialogTitle": "您確定要清除規則列表嗎？",
-  "createKanjiFilterDialogDesc1": "請在瀏覽器中使用Web搜索工具搜索特定的漢字或Yomikata，然後單擊按鈕開始編輯。另外，Yomikata必須採用片假名格式，不接受羅馬音和平假名。",
+  "createKanjiFilterDialogDesc1": "使用搜尋框跨頁查找漢字或讀音，然後點擊規則進行編輯。讀音必須使用片假名，不接受羅馬字和平假名。",
   "createKanjiFilterDialogDesc2": "“匹配全部”模式不能與Yomokata字段共存。如果切換到此模式，將清除原始的Yomokata字段，無法檢索。",
   "createKanjiFilterDialogTitle": "如何使用漢字過濾器？",
   "fieldMatchAll": "匹配全部",
@@ -139,5 +139,12 @@
   "tipClearText": "清除文本",
   "tipPleaseEnter": "請先輸入。",
   "placeholderTypeFurigana": "輸入文字生成假名",
-  "msgCopyFailed": "複製失敗。"
+  "msgCopyFailed": "複製失敗。",
+  "kanjiFilterSearch": "搜尋漢字或讀音",
+  "kanjiFilterMatchAllOnly": "僅顯示「匹配全部」規則",
+  "kanjiFilterPagination": "漢字過濾器分頁",
+  "kanjiFilterPrevious": "上一頁",
+  "kanjiFilterNext": "下一頁",
+  "kanjiFilterPage": "第 {{page}} / {{pages}} 頁 · 共 {{total}} 條規則",
+  "kanjiFilterNoResults": "沒有符合的規則。"
 }

--- a/extension/src/entrypoints/options/routes/KanjiFilter/index.tsx
+++ b/extension/src/entrypoints/options/routes/KanjiFilter/index.tsx
@@ -78,7 +78,7 @@ export function KanjiFilter() {
         <Button
           disabled={currentPage === 1}
           onClick={() => setPage(currentPage - 1)}
-          className="inline-flex cursor-pointer items-center justify-center rounded-md bg-sky-600 px-3 py-1.5 font-semibold text-sm text-white leading-6 shadow-xs focus-visible:outline-2 focus-visible:outline-sky-600 focus-visible:outline-offset-2 enabled:hover:bg-sky-500 disabled:cursor-not-allowed disabled:opacity-50"
+          className="inline-flex cursor-pointer items-center justify-center rounded-md bg-slate-950/5 px-3 py-2 text-slate-800 transition focus-visible:outline-2 focus-visible:outline-sky-600 focus-visible:outline-offset-2 enabled:hover:text-sky-500 disabled:cursor-not-allowed disabled:opacity-50 dark:bg-white/5 dark:text-white"
         >
           {t("kanjiFilterPrevious")}
         </Button>
@@ -92,7 +92,7 @@ export function KanjiFilter() {
         <Button
           disabled={currentPage === pageCount}
           onClick={() => setPage(currentPage + 1)}
-          className="inline-flex cursor-pointer items-center justify-center rounded-md bg-sky-600 px-3 py-1.5 font-semibold text-sm text-white leading-6 shadow-xs focus-visible:outline-2 focus-visible:outline-sky-600 focus-visible:outline-offset-2 enabled:hover:bg-sky-500 disabled:cursor-not-allowed disabled:opacity-50"
+          className="inline-flex cursor-pointer items-center justify-center rounded-md bg-slate-950/5 px-3 py-2 text-slate-800 transition focus-visible:outline-2 focus-visible:outline-sky-600 focus-visible:outline-offset-2 enabled:hover:text-sky-500 disabled:cursor-not-allowed disabled:opacity-50 dark:bg-white/5 dark:text-white"
         >
           {t("kanjiFilterNext")}
         </Button>

--- a/extension/src/entrypoints/options/routes/KanjiFilter/index.tsx
+++ b/extension/src/entrypoints/options/routes/KanjiFilter/index.tsx
@@ -1,11 +1,36 @@
+import { useMemo, useState } from "react";
+import { useTranslation } from "react-i18next";
 import { cn } from "@/cn";
 import { NotFoundRule } from "../../components/NotFoundRule";
 import { KanjiFilterDashboard } from "./components/KanjiFilterDashboard";
 import { KanjiFilterItem } from "./components/KanjiFilterItem";
 import { useKanjiFiltersStore } from "./store";
 
+const PAGE_SIZE = 100;
+
 export function KanjiFilter() {
   const kanjiFilters = useKanjiFiltersStore((state) => state.kanjiFilters);
+
+  const { t } = useTranslation();
+  const [query, setQuery] = useState("");
+  const [matchAllOnly, setMatchAllOnly] = useState(false);
+  const [page, setPage] = useState(1);
+  const filteredRules = useMemo(() => {
+    const search = query.trim();
+    return kanjiFilters.filter(
+      (rule) =>
+        !(matchAllOnly && rule.yomikatas) &&
+        (!search ||
+          rule.kanji.includes(search) ||
+          rule.yomikatas?.some((reading) => reading.includes(search))),
+    );
+  }, [kanjiFilters, query, matchAllOnly]);
+  const pageCount = Math.max(1, Math.ceil(filteredRules.length / PAGE_SIZE));
+  const currentPage = Math.min(page, pageCount);
+  if (page !== currentPage) {
+    setPage(currentPage);
+  }
+  const offset = (currentPage - 1) * PAGE_SIZE;
 
   return (
     <div
@@ -15,12 +40,61 @@ export function KanjiFilter() {
       )}
     >
       <KanjiFilterDashboard className="mb-5" disableExportAndClear={kanjiFilters.length === 0} />
-      {kanjiFilters.length > 0 ? (
+      <div className="mb-5 flex w-full flex-wrap items-center gap-3">
+        <input
+          type="search"
+          aria-label={t("kanjiFilterSearch")}
+          placeholder={t("kanjiFilterSearch")}
+          value={query}
+          onChange={(event) => {
+            setQuery(event.target.value);
+            setPage(1);
+          }}
+          className="min-w-0 flex-1 rounded-md border-slate-300 bg-transparent dark:border-slate-600"
+        />
+        <label className="flex items-center gap-2">
+          <input
+            type="checkbox"
+            checked={matchAllOnly}
+            onChange={(event) => {
+              setMatchAllOnly(event.target.checked);
+              setPage(1);
+            }}
+          />
+          {t("kanjiFilterMatchAllOnly")}
+        </label>
+      </div>
+      <nav aria-label={t("kanjiFilterPagination")} className="mb-5 flex items-center gap-3">
+        <button
+          disabled={currentPage === 1}
+          onClick={() => setPage(currentPage - 1)}
+          className="rounded-md px-3 py-2 hover:bg-slate-500/10 disabled:opacity-40"
+        >
+          {t("kanjiFilterPrevious")}
+        </button>
+        <output>
+          {t("kanjiFilterPage", {
+            page: currentPage,
+            pages: pageCount,
+            total: filteredRules.length,
+          })}
+        </output>
+        <button
+          disabled={currentPage === pageCount}
+          onClick={() => setPage(currentPage + 1)}
+          className="rounded-md px-3 py-2 hover:bg-slate-500/10 disabled:opacity-40"
+        >
+          {t("kanjiFilterNext")}
+        </button>
+      </nav>
+      {filteredRules.length > 0 ? (
         <div className="grid grid-cols-2 flex-wrap gap-3 sm:grid-cols-3 2xl:grid-cols-4">
-          {kanjiFilters.map((rule, index) => (
-            <KanjiFilterItem key={rule.kanji} rule={rule} index={index} />
+          {filteredRules.slice(offset, offset + PAGE_SIZE).map((rule, index) => (
+            <KanjiFilterItem key={rule.kanji} rule={rule} index={offset + index} />
           ))}
         </div>
+      ) : kanjiFilters.length > 0 ? (
+        <output>{t("kanjiFilterNoResults")}</output>
       ) : (
         <NotFoundRule />
       )}

--- a/extension/src/entrypoints/options/routes/KanjiFilter/index.tsx
+++ b/extension/src/entrypoints/options/routes/KanjiFilter/index.tsx
@@ -41,8 +41,8 @@ export function KanjiFilter() {
       )}
     >
       <KanjiFilterDashboard className="mb-5" disableExportAndClear={kanjiFilters.length === 0} />
-      <div className="mb-5 flex w-full flex-wrap items-center gap-3">
-        <Field className="min-w-0 flex-1">
+      <div className="mb-5 flex w-full flex-wrap items-center justify-center gap-3">
+        <Field className="w-64 max-w-full">
           <Label className="sr-only">{t("kanjiFilterSearch")}</Label>
           <Input
             type="search"
@@ -74,7 +74,18 @@ export function KanjiFilter() {
           </Switch>
         </Field>
       </div>
-      <nav aria-label={t("kanjiFilterPagination")} className="mb-5 flex items-center gap-3">
+      {filteredRules.length > 0 ? (
+        <div className="grid grid-cols-2 flex-wrap gap-3 sm:grid-cols-3 2xl:grid-cols-4">
+          {filteredRules.slice(offset, offset + PAGE_SIZE).map((rule, index) => (
+            <KanjiFilterItem key={rule.kanji} rule={rule} index={offset + index} />
+          ))}
+        </div>
+      ) : kanjiFilters.length > 0 ? (
+        <output>{t("kanjiFilterNoResults")}</output>
+      ) : (
+        <NotFoundRule />
+      )}
+      <nav aria-label={t("kanjiFilterPagination")} className="mt-5 flex items-center gap-3">
         <Button
           disabled={currentPage === 1}
           onClick={() => setPage(currentPage - 1)}
@@ -97,17 +108,6 @@ export function KanjiFilter() {
           {t("kanjiFilterNext")}
         </Button>
       </nav>
-      {filteredRules.length > 0 ? (
-        <div className="grid grid-cols-2 flex-wrap gap-3 sm:grid-cols-3 2xl:grid-cols-4">
-          {filteredRules.slice(offset, offset + PAGE_SIZE).map((rule, index) => (
-            <KanjiFilterItem key={rule.kanji} rule={rule} index={offset + index} />
-          ))}
-        </div>
-      ) : kanjiFilters.length > 0 ? (
-        <output>{t("kanjiFilterNoResults")}</output>
-      ) : (
-        <NotFoundRule />
-      )}
     </div>
   );
 }

--- a/extension/src/entrypoints/options/routes/KanjiFilter/index.tsx
+++ b/extension/src/entrypoints/options/routes/KanjiFilter/index.tsx
@@ -1,3 +1,4 @@
+import { Button, Field, Input, Label, Switch } from "@headlessui/react";
 import { useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { cn } from "@/cn";
@@ -41,37 +42,46 @@ export function KanjiFilter() {
     >
       <KanjiFilterDashboard className="mb-5" disableExportAndClear={kanjiFilters.length === 0} />
       <div className="mb-5 flex w-full flex-wrap items-center gap-3">
-        <input
-          type="search"
-          aria-label={t("kanjiFilterSearch")}
-          placeholder={t("kanjiFilterSearch")}
-          value={query}
-          onChange={(event) => {
-            setQuery(event.target.value);
-            setPage(1);
-          }}
-          className="min-w-0 flex-1 rounded-md border-slate-300 bg-transparent dark:border-slate-600"
-        />
-        <label className="flex items-center gap-2">
-          <input
-            type="checkbox"
-            checked={matchAllOnly}
+        <Field className="min-w-0 flex-1">
+          <Label className="sr-only">{t("kanjiFilterSearch")}</Label>
+          <Input
+            type="search"
+            placeholder={t("kanjiFilterSearch")}
+            value={query}
             onChange={(event) => {
-              setMatchAllOnly(event.target.checked);
+              setQuery(event.target.value);
               setPage(1);
             }}
+            className="block w-full rounded-md border-0 py-1.5 text-slate-900 shadow-xs ring-1 ring-gray-300 ring-inset placeholder:text-slate-400 focus:ring-2 focus:ring-sky-600 focus:ring-inset disabled:cursor-not-allowed sm:text-sm sm:leading-6 dark:bg-slate-900 dark:text-white dark:ring-gray-700 dark:focus:ring-sky-600"
           />
-          {t("kanjiFilterMatchAllOnly")}
-        </label>
+        </Field>
+        <Field className="flex items-center gap-2">
+          <Label className="font-semibold text-slate-950 text-sm/6 dark:text-white">
+            {t("kanjiFilterMatchAllOnly")}
+          </Label>
+          <Switch
+            checked={matchAllOnly}
+            onChange={(checked) => {
+              setMatchAllOnly(checked);
+              setPage(1);
+            }}
+            className="group relative flex h-5 w-10 shrink-0 cursor-pointer rounded-full bg-slate-900/10 p-1 transition duration-200 ease-in-out hover:backdrop-brightness-75 focus:outline-hidden data-checked:bg-sky-500 data-focus:outline-1 data-focus:outline-white dark:bg-white/10 dark:hover:backdrop-brightness-175"
+          >
+            <span
+              aria-hidden="true"
+              className="pointer-events-none inline-block size-3 translate-x-0 rounded-full bg-white shadow-lg ring-0 transition duration-200 ease-in-out group-data-checked:translate-x-5"
+            />
+          </Switch>
+        </Field>
       </div>
       <nav aria-label={t("kanjiFilterPagination")} className="mb-5 flex items-center gap-3">
-        <button
+        <Button
           disabled={currentPage === 1}
           onClick={() => setPage(currentPage - 1)}
-          className="rounded-md px-3 py-2 hover:bg-slate-500/10 disabled:opacity-40"
+          className="inline-flex cursor-pointer items-center justify-center rounded-md bg-sky-600 px-3 py-1.5 font-semibold text-sm text-white leading-6 shadow-xs focus-visible:outline-2 focus-visible:outline-sky-600 focus-visible:outline-offset-2 enabled:hover:bg-sky-500 disabled:cursor-not-allowed disabled:opacity-50"
         >
           {t("kanjiFilterPrevious")}
-        </button>
+        </Button>
         <output>
           {t("kanjiFilterPage", {
             page: currentPage,
@@ -79,13 +89,13 @@ export function KanjiFilter() {
             total: filteredRules.length,
           })}
         </output>
-        <button
+        <Button
           disabled={currentPage === pageCount}
           onClick={() => setPage(currentPage + 1)}
-          className="rounded-md px-3 py-2 hover:bg-slate-500/10 disabled:opacity-40"
+          className="inline-flex cursor-pointer items-center justify-center rounded-md bg-sky-600 px-3 py-1.5 font-semibold text-sm text-white leading-6 shadow-xs focus-visible:outline-2 focus-visible:outline-sky-600 focus-visible:outline-offset-2 enabled:hover:bg-sky-500 disabled:cursor-not-allowed disabled:opacity-50"
         >
           {t("kanjiFilterNext")}
-        </button>
+        </Button>
       </nav>
       {filteredRules.length > 0 ? (
         <div className="grid grid-cols-2 flex-wrap gap-3 sm:grid-cols-3 2xl:grid-cols-4">


### PR DESCRIPTION
The Kanji Filter page previously rendered every rule at once. It now displays 100 rules per page, with search across all kanji and readings and an option to show only Match ALL rules. Search and filter changes return to the first page, and deleting rules keeps the current page within range.

Updates all four supported translations and the editor help text for the new search controls.

Validation: repository lint and type checks, Chrome production build, and all five Kanji Filter Playwright tests passed, covering pagination, search, filtering, deletion persistence, clearing, and export.

Closes #403
