### PR TITLE
chore: add react-grab development tooling via catalog

### DIFF
--- a/extension/package.json
+++ b/extension/package.json
@@ -61,6 +61,7 @@
     "@vitejs/plugin-react": "^6.1.1",
     "@wxt-dev/auto-icons": "^1.1.2",
     "baseline-browser-mapping": "catalog:",
+    "react-grab": "catalog:",
     "react-scan": "catalog:",
     "tailwindcss": "catalog:",
     "vite-plugin-svgr": "^5.2.0",

--- a/extension/src/entrypoints/options/main.tsx
+++ b/extension/src/entrypoints/options/main.tsx
@@ -1,4 +1,5 @@
 if (import.meta.env.DEV) {
+  await import("react-grab");
   const { scan } = await import("react-scan");
   scan({ enabled: true });
 }

--- a/extension/src/entrypoints/popup/main.tsx
+++ b/extension/src/entrypoints/popup/main.tsx
@@ -1,3 +1,7 @@
+if (import.meta.env.DEV) {
+  await import("react-grab");
+}
+
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { ThemeProvider } from "next-themes";
 import { StrictMode } from "react";

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -60,6 +60,9 @@ catalogs:
     react-dom:
       specifier: ^19.3.0
       version: 19.3.0
+    react-grab:
+      specifier: ^0.2.0
+      version: 0.2.0
     react-router:
       specifier: ^8.3.1
       version: 8.3.1
@@ -234,6 +237,9 @@ importers:
       baseline-browser-mapping:
         specifier: 'catalog:'
         version: 2.11.21
+      react-grab:
+        specifier: 'catalog:'
+        version: 0.2.0(react@19.3.0)
       react-scan:
         specifier: 'catalog:'
         version: 0.5.7(@opentelemetry/core@2.11.0(@opentelemetry/api@1.9.1))(esbuild@0.27.7)(eslint@10.10.0(jiti@2.7.0)(supports-color@10.2.2))(react-dom@19.3.0(react@19.3.0))(react@19.3.0)(rollup@4.60.4)(supports-color@10.2.2)
@@ -322,6 +328,9 @@ importers:
       '@types/react-dom':
         specifier: 'catalog:'
         version: 19.3.0(@types/react@19.3.0)
+      react-grab:
+        specifier: 'catalog:'
+        version: 0.2.0(react@19.3.0)
       tailwindcss:
         specifier: 'catalog:'
         version: 4.3.3

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -32,6 +32,7 @@ catalog:
   react: ^19.3.0
   react-dom: ^19.3.0
   react-router: ^8.3.1
+  react-grab: ^0.2.0
   react-scan: ^0.5.7
   tailwind-merge: ^3.6.0
   tailwindcss: ^4.3.3

--- a/website/app/entry.client.tsx
+++ b/website/app/entry.client.tsx
@@ -1,3 +1,7 @@
+if (import.meta.env.DEV) {
+  await import("react-grab");
+}
+
 import { StrictMode, startTransition } from "react";
 import { hydrateRoot } from "react-dom/client";
 import { HydratedRouter } from "react-router/dom";

--- a/website/package.json
+++ b/website/package.json
@@ -35,6 +35,7 @@
     "@tailwindcss/vite": "catalog:",
     "@types/react": "catalog:",
     "@types/react-dom": "catalog:",
+    "react-grab": "catalog:",
     "tailwindcss": "catalog:",
     "vite": "catalog:",
     "vite-plugin-devtools-json": "^1.1.0",


### PR DESCRIPTION
Adds react-grab to the extension options page, popup, and website client for use during development. The package version is managed through the shared pnpm catalog, and imports run only when `import.meta.env.DEV` is true.

Validation: frozen-lockfile install, repository lint and type checks, extension production build, and website production build all passed.
